### PR TITLE
Always upload completion results

### DIFF
--- a/.github/workflows/switcher-requirements-progress.yml
+++ b/.github/workflows/switcher-requirements-progress.yml
@@ -81,6 +81,7 @@ jobs:
         fi
 
     - name: Upload potodo results
+      if: always()
       uses: actions/upload-artifact@v4
       with:
         name: potodo-results-${{ inputs.language_code }}


### PR DESCRIPTION
Closes https://github.com/python-docs-translations/switcher-progress/issues/4

Note, it is always visible in the "Run potodo" step, [e.g.](https://github.com/python-docs-translations/switcher-progress/actions/runs/18012397071/job/51248348724)